### PR TITLE
fix:15 attributeerror in save function when no entry is found with the provided primary key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datamodel-router"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   { name = "Tobias Ahlers", email = "93325697+TobiasAhlers@users.noreply.github.com" },
 ]

--- a/src/data_model_router/main.py
+++ b/src/data_model_router/main.py
@@ -10,7 +10,7 @@ from .utils import extract_and_validate_query_params, generate_function
 
 class DataModelRouter(APIRouter):
     def __init__(
-        self, data_model: DataModel, prefix: str | None = None, *args, **kwargs
+        self, data_model: type[DataModel], prefix: str | None = None, *args, **kwargs
     ) -> None:
         super().__init__(
             prefix=prefix if prefix is not None else f"/{data_model.__name__.lower()}",
@@ -83,6 +83,8 @@ class DataModelRouter(APIRouter):
                         ]
                     }
                 )
+                if data is None:
+                    data = self.data_model(**query_params)
                 for key, value in query_params.items():
                     setattr(data, key, value)
             else:

--- a/tests/DataModelRouter/test_DataModelRouter_save.py
+++ b/tests/DataModelRouter/test_DataModelRouter_save.py
@@ -46,3 +46,29 @@ def test_multiple_models(client: TestClient):
     )
     assert response.status_code == 200
     assert response.json() == {"id": 2, "country": "USA", "city": "New York"}
+
+
+def test_create_new_model(client: TestClient):
+    """
+    Test that a new model is created when the primary key is not provided.
+    """
+    response = client.post(
+        "testdatamodel2/save", params={"country": "USA", "city": "New York"}
+    )
+    assert response.status_code == 200
+
+    response = client.get("testdatamodel2/get_one", params={"id": 1})
+    assert response.status_code == 200
+
+
+def test_save_new_with_id(client: TestClient):
+    """
+    Test that a new model is created with the provided primary key.
+    """
+    response = client.post(
+        "testdatamodel2/save", params={"id": 3, "country": "USA", "city": "New York"}
+    )
+    assert response.status_code == 200
+
+    response = client.get("testdatamodel2/get_one", params={"id": 1})
+    assert response.status_code == 200


### PR DESCRIPTION
Fix issue where router incorrectly assumes entry with given primary key already exists

- Modified the save function to correctly handle cases where an entry with the provided primary key does not exist in the database.
- Ensured that a new entry is created if the primary key does not match any existing entries.

Closes #15 